### PR TITLE
fixes for gnu c++11

### DIFF
--- a/src/mp4util.h
+++ b/src/mp4util.h
@@ -33,7 +33,7 @@ namespace mp4v2 { namespace impl {
 #ifndef ASSERT
 #   define ASSERT(expr) \
         if (!(expr)) { \
-            throw new Exception("assert failure: "LIBMPV42_STRINGIFY((expr)), __FILE__, __LINE__, __FUNCTION__ ); \
+            throw new Exception("assert failure: " LIBMPV42_STRINGIFY((expr)), __FILE__, __LINE__, __FUNCTION__ ); \
         }
 #endif
 

--- a/src/rtphint.cpp
+++ b/src/rtphint.cpp
@@ -339,7 +339,7 @@ void MP4RtpHintTrack::GetPayload(
                 pSlash = strchr(pSlash, '/');
                 if (pSlash != NULL) {
                     pSlash++;
-                    if (pSlash != '\0') {
+                    if (*pSlash != '\0') {
                         length = (uint32_t)strlen(pRtpMap) - (pSlash - pRtpMap);
                         *ppEncodingParams = (char *)MP4Calloc(length + 1);
                         strncpy(*ppEncodingParams, pSlash, length);


### PR DESCRIPTION
I'm not much of a c++ coder really but when I try to build this project with Rust it complained about the lack of space between the macro and the string quotes and also it said can't compare numbers and pointers, so I've fixed those two things and it compiles now. I'm trying to use this in the rust-media library but it won't build because of these issues too.

Thanks!